### PR TITLE
header fixes only for the jupyter books better displays.

### DIFF
--- a/notebooks/NEON_Visualization_Tutorial.ipynb
+++ b/notebooks/NEON_Visualization_Tutorial.ipynb
@@ -42,7 +42,7 @@
    "metadata": {},
    "source": [
     "________\n",
-    "<h2> 1. Explore CLM model data </h2>\n",
+    "# 1. Explore CLM model data\n",
     "\n",
     "There are countless ways of analyzing and processing model data. This tutorial uses Matplotlib, a comprehensive data visualization and plotting library for Python. For more information on Matplotlib, please see the [User's Guide](https://matplotlib.org/stable/users/index.html)."
    ]
@@ -73,7 +73,7 @@
    "metadata": {},
    "source": [
     "***\n",
-    "<h3> 1.1 Locate model data </h3>\n",
+    "## 1.1 Locate model data\n",
     "\n",
     "When the simulation completes, the data are transferred to an `archive` directory. In this directory, there are files that include data for every day of the simulation, as well as files that average model variables monthly. <p>\n",
     "\n",
@@ -129,7 +129,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h3>1.2 Explore Simulated Data </h3>\n",
+    "## 1.2 Explore Simulated Data\n",
     "\n",
     "This step has several components, which are broken into smaller steps\n"
    ]
@@ -138,7 +138,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4>1.2.1 Load Python Libraries</h4>\n",
+    "### 1.2.1 Load Python Libraries\n",
     "\n",
     "*Run the below code to import the required python libraries*"
    ]
@@ -176,7 +176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4>1.2.2 Select Simulation Year</h4>\n",
+    "### 1.2.2 Select Simulation Year\n",
     "\n",
     "For simplicity, we focus on analyzing and evaluating a single year of data. <p>\n",
     "\n",
@@ -198,7 +198,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4>1.2.3 Load model data files</h4>\n",
+    "### 1.2.3 Load model data files\n",
     "\n",
     "For reading the netCDF files, we are using the `xarray` Python package. You can learn more about [xarray on this website](http://xarray.pydata.org/en/stable/).\n",
     "\n",
@@ -223,7 +223,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4> 1.2.4 Open model data files </h4>\n",
+    "### 1.2.4 Open model data files\n",
     "\n",
     "Here we use the python function `xarray.open_mfdataset`, which opens multiple netcdf files as a single xarray dataset. For more information on this xarray function, visit [the xarray website](\n",
     "http://xarray.pydata.org/en/stable/generated/xarray.open_mfdataset.html).\n",
@@ -249,7 +249,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4> 1.2.5 Optional Step: Explore dataset from simulations </h4>\n",
+    "### 1.2.5 Optional Step: Explore dataset from simulations\n",
     "\n",
     "This step looks at the dataset that was just created from the simulation data. This step is not required, but will allow you to explore the python dataset and become familiar with the data.\n",
     "\n",
@@ -296,9 +296,9 @@
    "metadata": {},
    "source": [
     "________\n",
-    "<h2> 2. Explore NEON Tower Observation Data </h2>\n",
+    "# 2. Explore NEON Tower Observation Data\n",
     "\n",
-    "<h3> 2.1 Download NEON data </h3>\n",
+    "## 2.1 Download NEON data\n",
     "\n",
     "**A note about NEON evaluation data**: NEON data for evaluation are pulled from the API and the least restrictive quality control flags are applied. The data are subsequently gap-filled using a redundant data stream regression, while data that are still missing are filled using a Marginal Distribution Sampling (MDS) gap-filling technique. Unit conversions are performed and the data are formatted and supplied as monthly netCDF files. \n",
     "\n",
@@ -327,7 +327,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h3> 2.2 Load NEON data </h3>\n",
+    "## 2.2 Load NEON data\n",
     "   \n",
     "*Run the two cells of code below. The code will print a list of files for the year specified above and read them into a dataset.*"
    ]
@@ -370,7 +370,7 @@
     "So far, we uploaded files of observational and model data. In this section we will compare observed and simulated **latent heat fluxes**. You can also explore other available variables with this code.\n",
     "***\n",
     "\n",
-    "#### Format Data\n",
+    "### Format Data\n",
     "The next cell of code processes the data into a common format to make analysis easier.\n",
     "<br/>\n",
     "\n",
@@ -434,7 +434,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 3.1 What is latent heat flux?\n",
+    "## 3.1 What is latent heat flux?\n",
     "\n",
     "Below we explore how well CLM simulates latent heat flux, which is directly observed at NEON towers. Latent heat flux is the energy for water evaporation from the ecosystem. Latent heat flux is a combination of plant transpiration, evaporation from leaf surfaces (e.g., from dew, after precipitation events, etc.), and evaporation from the soil:\n",
     "\n",
@@ -502,14 +502,14 @@
    "metadata": {},
    "source": [
     "****\n",
-    "### 3.2 Plotting latent heat flux"
+    "## 3.2 Plotting latent heat flux"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 3.2.1 Daily Timeseries\n",
+    "### 3.2.1 Daily Timeseries\n",
     "This creates a time-series plot comparing daily average latent heat flux from observations (NEON) and simulations (CLM). To start, we need calculate the daily averages. Run the below cells of code to create the averages and plot.\n",
     "\n",
     "*First, we need to extract year, month, day and hour from time column*"
@@ -631,7 +631,7 @@
    "metadata": {},
    "source": [
     "*****\n",
-    "#### 3.2.2 Monthly Averages & Component Fluxes: Absolute Values\n",
+    "### 3.2.2 Monthly Averages & Component Fluxes: Absolute Values\n",
     "\n",
     "Next we will disentangle whether transpiration, canopy evaporation, or ground evaporation is the dominant contribution to latent heat flux during each month using CLM data. As mentioned in section 3.1, NEON observations cannot distinguish how much each of these processes contributes to latent heat fluxes. \n",
     "\n",
@@ -712,7 +712,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 3.2.3 Monthly Averages & Component Fluxes: Proportional Contributions\n",
+    "### 3.2.3 Monthly Averages & Component Fluxes: Proportional Contributions\n",
     "It might be easier to see the proportional contributions of transpiration and evaporation fluxes to total latent heat flux. The code below makes a more advanced plot with two y-axes that helps to illustrate the absolute values of monthly latent heat fluxes and the proportion of component fluxes each month. "
    ]
   },
@@ -758,7 +758,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### 3.2.4 Annual and Seasonal Correlations\n",
+    "### 3.2.4 Annual and Seasonal Correlations\n",
     "Scatter plots can help to describe the relationship between latent heat flux and the component transpiration and evaporation fluxes. We can look at these relationships using data from CLM simulations.\n",
     "\n",
     "First, plot annual average relationships.\n",
@@ -923,7 +923,7 @@
    "metadata": {},
    "source": [
     "--------\n",
-    "#### 3.2.5 Average Diel Cycle\n",
+    "### 3.2.5 Average Diel Cycle\n",
     "\n",
     "Latent heat flux also changes throughout the day. Does CLM capture the diel cycle that NEON observes? We can compare the average diel cycle from NEON observations and CLM simulations to find out. \n",
     "\n",
@@ -1072,9 +1072,17 @@
     "1. Determined when transpiration and evaporation fluxes drive latent heat fluxes\n",
     "1. Learned how to average over different time periods and create different types of plots\n",
     "\n",
-    "#### If you would like to learn more advanced interactive visualization tools, please check back for an advanced tutorial that is coming soon!\n",
+    "**If you would like to learn more advanced interactive visualization tools, please check back for an advanced tutorial that is coming soon!**\n",
+    "\n",
     "You can also use this script to explore additional CLM and NEON data by changing the variables in section 3 of this script.\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Changing the title header to markdown formatting so that it can be displayed better for the jupyter books side bar on left. 
