### PR TITLE
removing PCT_CLAY for plot_soil_profile_timeseries

### DIFF
--- a/notebooks/neon_utils.py
+++ b/notebooks/neon_utils.py
@@ -92,7 +92,7 @@ def plot_soil_profile_timeseries(sim_path, neon_site, case_name, var, year):
     
     ds_all = []
     for f in tqdm.tqdm(sim_files):
-        ds_tmp = xr.open_dataset(f,drop_variables=['ZSOI','DZSOI','WATSAT','SUCSAT','BSW','HKSAT','ZLAKE','DZLAKE','PCT_SAND'])
+        ds_tmp = xr.open_dataset(f,drop_variables=['ZSOI','DZSOI','WATSAT','SUCSAT','BSW','HKSAT','ZLAKE','DZLAKE','PCT_SAND','PCT_CLAY'])
         ds_all.append(ds_tmp.isel(time = 24))
     
     ds_ctsm = xr.concat (ds_all,dim='time')


### PR DESCRIPTION
It seems like we are now writing PCT_CLAY to the history variables. However Brian Dobbins mentioned he receives an error when trying to use plot_soil_profile_timeseries function.

Since for this function, we don't need this variable we decided to use drop_variables basically not to read the PCT_CLAY variable for the plot_soil_profile_timeseries...